### PR TITLE
Implement patch helpers and fix agent

### DIFF
--- a/app/self_improve.py
+++ b/app/self_improve.py
@@ -121,3 +121,24 @@ class SelfImproveEngine:
     def _restore(self, backup_path):
         shutil.rmtree('app')
         shutil.copytree(backup_path, 'app')
+
+    def _apply_patch(self, diff_text: str) -> bool:
+        """Apply a unified diff using the ``patch`` command."""
+        proc = subprocess.run([
+            "patch",
+            "-p1",
+        ], input=diff_text, text=True, capture_output=True)
+        if proc.returncode != 0:
+            print("[SelfImprove] Patch failed:\n", proc.stdout, proc.stderr)
+            return False
+        return True
+
+    def _run_tests(self):
+        """Run ``self.test_cmd`` and return the CompletedProcess."""
+        return subprocess.run(
+            self.test_cmd,
+            shell=True,
+            text=True,
+            capture_output=True,
+        )
+


### PR DESCRIPTION
## Summary
- add methods `_apply_patch` and `_run_tests` to `SelfImproveEngine`
- default `Agent` to use the real LLM and simplify stub path
- guard RL policy use when none is loaded

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684019435978832185d572e07d845189