### PR TITLE
Improve PPO defaults and fix agent tests

### DIFF
--- a/batch_self_improve.py
+++ b/batch_self_improve.py
@@ -41,15 +41,15 @@ def main():
         "MlpPolicy",
         vec_env,
         verbose=1,
-        learning_rate=5e-4,
-        n_steps=800,       # rollout length per env
+        learning_rate=3e-4,
+        n_steps=2048,  # rollout length per env
         batch_size=64,
-        n_epochs=5,
-        ent_coef=0.05,
-        device="cuda",
+        n_epochs=10,
+        ent_coef=0.0,
+        device="auto",
         clip_range=0.2,
-        gamma=0.995,
-        gae_lambda=0.9,
+        gamma=0.99,
+        gae_lambda=0.95,
     )
 
     timesteps_per_iteration = 100000

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -6,7 +6,9 @@ from app.agent import Agent
 
 @pytest.fixture
 def agent():
-    return Agent()
+    # use_real_llm=True to ensure ask_llm calls network layer,
+    # which will be mocked during tests
+    return Agent(use_real_llm=True)
 
 def make_response(content_lines, done=True):
     """Helper to simulate streaming lines from requests."""


### PR DESCRIPTION
## Summary
- tweak PPO hyperparameters in `batch_self_improve.py`
- ensure `ask_llm` is exercised in unit tests by setting `use_real_llm=True`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404e5dae708321a9b508d964c32da2