### PR TITLE
Add self_improve_threshold to default.yaml

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,0 +1,5 @@
+trainer:
+  batch_size: 32
+  learning_rate: 1e-4
+  num_epochs: 5
+  self_improve_threshold: 100  # New: how many memory entries before auto fine-tune


### PR DESCRIPTION
## Summary
- add configs/default.yaml with new self_improve_threshold trainer setting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68414b000e248321ad3e239b3ae2670a