### PR TITLE
Add scheduler for periodic fine-tuning

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,0 +1,6 @@
+trainer:
+  batch_size: 32
+  learning_rate: 1e-4
+  num_epochs: 5
+  self_improve_threshold: 100
+  self_improve_interval: 60   # New: minutes between periodic fine-tunes

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -1,0 +1,28 @@
+import yaml
+from apscheduler.schedulers.background import BackgroundScheduler
+from trainer import Trainer
+
+
+def periodic_fine_tune(config_path: str = "configs/default.yaml"):
+    """Reads config, fine-tunes on the current memory buffer every X minutes."""
+    with open(config_path, "r") as f:
+        cfg = yaml.safe_load(f)
+
+    interval_minutes = cfg.get("trainer", {}).get("self_improve_interval", 60)
+    trainer = Trainer(config_path=config_path)
+
+    scheduler = BackgroundScheduler()
+    scheduler.add_job(trainer.fine_tune, "interval", minutes=interval_minutes, next_run_time=None)
+    scheduler.start()
+
+    print(f"[Scheduler] Scheduled fine-tune every {interval_minutes} minutes.")
+    try:
+        # Keep the scheduler thread alive indefinitely
+        scheduler._event.wait()
+    except (KeyboardInterrupt, SystemExit):
+        scheduler.shutdown()
+        print("[Scheduler] Shutdown complete.")
+
+
+if __name__ == "__main__":
+    periodic_fine_tune()


### PR DESCRIPTION
## Summary
- add `src/scheduler.py` implementing periodic fine-tuning
- introduce `configs/default.yaml` with new `self_improve_interval` setting

## Testing
- `pip install -q -r requirements.txt` *(failed: Operation cancelled)*
- `pytest -q` *(failed to collect due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68414b2659f48321aea32833efee17ad